### PR TITLE
Add buffer before getting its name in diagnostic list

### DIFF
--- a/autoload/coc_fzf/diagnostics.vim
+++ b/autoload/coc_fzf/diagnostics.vim
@@ -20,7 +20,12 @@ function! coc_fzf#diagnostics#fzf_run(...) abort
 endfunction
 
 function! s:format_coc_diagnostic(item) abort
-  return (has_key(a:item,'file')  ? bufname(a:item.file) : '')
+  let l:file = ''
+  if has_key(a:item, 'file')
+    let l:relPath = substitute(a:item.file, getcwd() . "/" , "", "")
+    let l:file = bufname(bufadd(l:relPath))
+  endif
+  return l:file
         \ . ':' . a:item.lnum . ':' . a:item.col . ' '
         \ . a:item.severity . ' ' . a:item.message
 endfunction


### PR DESCRIPTION
Fixes #11

I'm not 100% sure this is the right thing to do, to load the buffersj
strictly. It seems to me it would be nicer to just store the filename
here and only load the buffer if the user selects it. This also seems to
display the full path to the current buffer sometimes :/

I'm sure someone with better vim scripting skills can do a better job at
this.