### PR TITLE
Ignore the common_fzf_vim directory

### DIFF
--- a/script/get_lists.sh
+++ b/script/get_lists.sh
@@ -7,6 +7,7 @@ coc_fzf_source_dir="$(dirname $0)/../autoload/coc_fzf"
 for f in $(ls "$coc_fzf_source_dir"); do
   src="${f/%.vim/}"
   [ "$src" = "common" ] && continue
+  [ "$src" = "common_fzf_vim" ] && continue
   [ "$src" = "lists" ] && continue
   printf "$src"
   if [ "$description" = 1 ]; then


### PR DESCRIPTION
This should fix the `diagnostics` list entry

Before:
<img width="300" src="https://user-images.githubusercontent.com/6413797/77632757-5c96c500-6f46-11ea-9933-b29f970a0497.png">

After:
<img width="300" src="https://user-images.githubusercontent.com/6413797/77632754-5bfe2e80-6f46-11ea-8811-df88aeb5a1d6.png">

