### PR TITLE
Allow customising fzf parameters and preview location

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,16 @@ The goal is to keep the [coc.nvim][coc.nvim] style and leverage your [FZF Vim in
 Commands
 ---------
 
-| Command                                 | List                                                                             |
-| ---                                     | ---                                                                              |
+| Command                                   | List                                                                             |
+| ---                                       | ---                                                                              |
 | `:CocFzfList        `                     | Equivalent to :CocList                                                           |
 | `:CocFzfList actions`                     | Equivalent to :CocList actions                                                   |
 | `:CocFzfList commands`                    | Equivalent to :CocList commands                                                  |
 | `:CocFzfList diagnostics`                 | Equivalent to :CocList diagnostics. Toggle preview: '?'                          |
 | `:CocFzfList diagnostics --current-buf`   | Equivalent to :CocList diagnostics in the current buffer only                    |
 | `:CocFzfList extensions`                  | Equivalent to :CocList extensions                                                |
-| `:CocFzfList location`                    | Equivalent to :CocList location. Toggle preview: '?'. Requires [fzf.vim][fzfvim]           |
-| `:CocFzfList outline`                     | Equivalent to :CocList outline, with colors. Requires [ctags][ctags]                      |
+| `:CocFzfList location`                    | Equivalent to :CocList location. Toggle preview: '?'. Requires [fzf.vim][fzfvim] |
+| `:CocFzfList outline`                     | Equivalent to :CocList outline, with colors. Requires [ctags][ctags]             |
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                                   |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                      |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                                  |
@@ -34,9 +34,11 @@ Commands
 Options
 ---------
 
-| Option                                  | Description                                                                      |
-| ---                                     | ---                                                                              |
-| `g:coc_fzf_preview_toggle_key`            | Change default key '?' to toggle the preview window                              |
+| Option                         | Type   | Description                                                    | Default value               |
+| ---                            | ---    | ---                                                            | ---                         |
+| `g:coc_fzf_preview_toggle_key` | string | Change the key to toggle the preview window                    | `'?'`                       |
+| `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
+| `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. `['--layout=reverse']` | `['--layout=reverse-list']` |
 
 Vimrc Example
 ---------

--- a/autoload/coc_fzf/actions.vim
+++ b/autoload/coc_fzf/actions.vim
@@ -11,7 +11,7 @@ function! coc_fzf#actions#fzf_run() abort
           \ 'source': s:get_actions(),
           \ 'sink*': function('s:action_handler'),
           \ 'options': ['--multi', '--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     call fzf#run(fzf#wrap(l:opts))
     call s:syntax()

--- a/autoload/coc_fzf/commands.vim
+++ b/autoload/coc_fzf/commands.vim
@@ -11,7 +11,7 @@ function! coc_fzf#commands#fzf_run() abort
           \ 'source': s:get_commands(l:cmds),
           \ 'sink*': function('s:command_handler'),
           \ 'options': ['--multi', '--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     call fzf#run(fzf#wrap(l:opts))
     call s:syntax()

--- a/autoload/coc_fzf/diagnostics.vim
+++ b/autoload/coc_fzf/diagnostics.vim
@@ -12,11 +12,11 @@ function! coc_fzf#diagnostics#fzf_run(...) abort
           \ 'source': s:get_diagnostics(l:diags, l:current_buffer_only),
           \ 'sink*': function('s:error_handler'),
           \ 'options': ['--multi','--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     let extra = {}
     if g:coc_fzf_preview_available
-      let extra = fzf#vim#with_preview('up:50%', get(g:, 'coc_fzf_preview_toggle_key', '?'))
+      let extra = fzf#vim#with_preview(g:coc_fzf_preview, g:coc_fzf_preview_toggle_key)
     endif
     let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
     let merged = extend(copy(l:opts), extra)

--- a/autoload/coc_fzf/extensions.vim
+++ b/autoload/coc_fzf/extensions.vim
@@ -12,7 +12,7 @@ function! coc_fzf#extensions#fzf_run(...) abort
           \ 'source': s:get_extensions(l:exts),
           \ 'sink*': function('s:extension_handler'),
           \ 'options': ['--multi','--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     call fzf#run(fzf#wrap(l:opts))
     call s:syntax()

--- a/autoload/coc_fzf/location.vim
+++ b/autoload/coc_fzf/location.vim
@@ -12,10 +12,10 @@ function! coc_fzf#location#fzf_run() abort
           \ 'source': s:get_location(l:locs),
           \ 'sink*': function('s:location_handler'),
           \ 'options': ['--multi','--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt]
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     let extra = fzf#vim#with_preview({'options': '--delimiter : --nth 4..'},
-          \ 'up:50%', get(g:, 'coc_fzf_preview_toggle_key', '?'))
+          \ g:coc_fzf_preview, g:coc_fzf_preview_toggle_key)
     let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
     let merged = extend(copy(l:opts), extra)
     call coc_fzf#common_fzf_vim#merge_opts(merged, eopts)

--- a/autoload/coc_fzf/outline.vim
+++ b/autoload/coc_fzf/outline.vim
@@ -9,7 +9,7 @@ function! coc_fzf#outline#fzf_run() abort
         \ 'source': s:get_outline(),
         \ 'sink*': function('s:symbol_handler'),
         \ 'options': ['--multi','--expect='.expect_keys,
-        \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+        \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
         \ }
   call fzf#run(fzf#wrap(l:opts))
   call s:syntax()

--- a/autoload/coc_fzf/services.vim
+++ b/autoload/coc_fzf/services.vim
@@ -12,7 +12,7 @@ function! coc_fzf#services#fzf_run(...) abort
           \ 'source': s:get_services(l:serv),
           \ 'sink*': function('s:service_handler'),
           \ 'options': ['--multi','--expect='.expect_keys,
-          \ '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+          \ '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
           \ }
     call fzf#run(fzf#wrap(l:opts))
     call s:syntax()

--- a/autoload/coc_fzf/symbols.vim
+++ b/autoload/coc_fzf/symbols.vim
@@ -25,7 +25,7 @@ function! coc_fzf#symbols#fzf_run(...) abort
         \ 'source': initial_command,
         \ 'sink*': function('s:symbol_handler'),
         \ 'options': ['--multi','--expect='.expect_keys, '--bind', 'change:reload:'.reload_command,
-        \ '--phony', '--layout=reverse-list', '--ansi', '--prompt=' . s:prompt],
+        \ '--phony', '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts,
         \ }
   call fzf#run(fzf#wrap(l:opts))
   call s:syntax()

--- a/doc/coc-fzf.txt
+++ b/doc/coc-fzf.txt
@@ -53,8 +53,10 @@ Commands ~
                                                               *coc-fzf-options*
 Options ~
 
-| Option                       | Description                                         | ~
-| `g:coc_fzf_preview_toggle_key` | Change default key '?' to toggle the preview window |
+| Option                       | Type   | Description                                                    | Default value               | ~
+| `g:coc_fzf_preview_toggle_key` | string | Change the key to toggle the preview window                    | `'?'`                       |
+| `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
+| `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. `['--layout=reverse']` | `['--layout=reverse-list']` |
 
 
 ===============================================================================

--- a/plugin/coc_fzf.vim
+++ b/plugin/coc_fzf.vim
@@ -13,6 +13,16 @@ if !has('nvim')
   finish
 endif
 
+if !exists("g:coc_fzf_preview_toggle_key")
+    let g:coc_fzf_preview_toggle_key = '?'
+endif
+if !exists("g:coc_fzf_preview")
+    let g:coc_fzf_preview = 'up:50%'
+endif
+if !exists("g:coc_fzf_opts")
+    let g:coc_fzf_opts = ['--layout=reverse-list']
+endif
+
 " test plugin and bin availability
 let g:coc_fzf_preview_available = 1
 try


### PR DESCRIPTION
I'm already using `fzf` for a few things and I'd like the layout to be consistent across the board. Instead of imposing the fzf layout or the preview location on the user, make those configurable