### PR TITLE
Jump to start of workplace symbols (fixes #20)

### DIFF
--- a/script/get_workspace_symbols.py
+++ b/script/get_workspace_symbols.py
@@ -56,8 +56,8 @@ if items is None or items is 0:
     exit(0)
 
 for item in items:
-    lnum = item['location']['range']['end']['line'] + 1
-    col = item['location']['range']['end']['character']
+    lnum = item['location']['range']['start']['line'] + 1
+    col = item['location']['range']['start']['character']
     filename = item['location']['uri'].replace('file://', '')
     kind = get_kind(item['kind'])
     if args.kind is not None and args.kind[0].lower() != kind.lower():


### PR DESCRIPTION
Currently selecting a symbol from `CocFzfList symbols` jumps to the _end_ of the symbol's range - for example, if you select a function symbol in a TypeScript project, your cursor will be placed at the closing brace of the function definition. That's different than `CocList symbols`, which places you at the _start_ of the symbol's range - in the TypeScript function example, this is the first line of the function definition.

This PR makes `CocFzfList symbols` behave like `CocList symbols` - selecting a symbol will now place you at the start of the symbol's range.