### PR TITLE
Yanks list support based on coc-yank

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Commands
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                                   |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                      |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                                  |
-| `:CocFzfList yanks`                       | Equivalent to :CocList yanks. Requires [coc-yank][coc-yank]                      |
+| `:CocFzfList yanks`                       | Equivalent to :CocList yank. Requires [coc-yank][coc-yank]                       |
 | `:CocFzfListResume`                       | Equivalent to :CocListResume                                                     |
 
 Options

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Commands
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                                   |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                      |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                                  |
-| `:CocFzfList yanks`                       | Equivalent to :CocList yank. Requires [coc-yank][coc-yank]                       |
+| `:CocFzfList yank`                        | Equivalent to :CocList yank. Requires [coc-yank][coc-yank]                       |
 | `:CocFzfListResume`                       | Equivalent to :CocListResume                                                     |
 
 Options

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Commands
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                                   |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                      |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                                  |
+| `:CocFzfList yanks`                       | Equivalent to :CocList yanks. Requires [coc-yank][coc-yank]                      |
 | `:CocFzfListResume`                       | Equivalent to :CocListResume                                                     |
 
 Options
@@ -86,3 +87,4 @@ MIT
 [coc_denite]:          https://github.com/neoclide/coc-denite
 [ctags]:               https://github.com/universal-ctags/ctags
 [fzfvim]:              https://github.com/junegunn/fzf.vim
+[coc-yank]:            https://github.com/neoclide/coc-yank

--- a/autoload/coc_fzf/yank.vim
+++ b/autoload/coc_fzf/yank.vim
@@ -1,9 +1,9 @@
 " description: list of yanks provided by coc-yank
 
-let s:prompt = 'Coc Yanks> '
+let s:prompt = 'Coc Yank> '
 let s:yank_relative_file_path = '/coc-yank-data/yank'
 
-function! coc_fzf#yanks#fzf_run() abort
+function! coc_fzf#yank#fzf_run() abort
   call coc_fzf#common#log_function_call(expand('<sfile>'), a:000)
   let l:yank_file_path = coc#util#extension_root() . s:yank_relative_file_path
   let l:raw_yanks = readfile(l:yank_file_path)

--- a/autoload/coc_fzf/yanks.vim
+++ b/autoload/coc_fzf/yanks.vim
@@ -29,6 +29,12 @@ function! s:get_yanks(raw_yanks) abort
     endif
   endfor
 
+  " make sure our list empty; if not, add it to the list
+  if len(yank_parts) != 0
+    let l:yank = join(yank_parts, "\n")
+    call add(l:yanks, l:yank)
+  endif
+
   return reverse(l:yanks)
 endfunction
 

--- a/autoload/coc_fzf/yanks.vim
+++ b/autoload/coc_fzf/yanks.vim
@@ -1,0 +1,38 @@
+" description: list of yanks provided by coc-yank
+
+let s:prompt = 'Coc Yanks> '
+let s:yank_file_path = $HOME . '/.config/coc/extensions/coc-yank-data/yank'
+
+function! coc_fzf#yanks#fzf_run() abort
+  call coc_fzf#common#log_function_call(expand('<sfile>'), a:000)
+  let l:raw_yanks = readfile(s:yank_file_path)
+  let l:opts = {
+        \ 'source': s:get_yanks(l:raw_yanks),
+        \ 'sink*': function('s:yank_handler'),
+        \ 'options': ['--multi', '--ansi', '--prompt=' . s:prompt] + g:coc_fzf_opts
+        \ }
+  call fzf#run(fzf#wrap(l:opts))
+endfunction
+
+function! s:get_yanks(raw_yanks) abort
+  let l:yanks = []
+  let l:yank_parts = []
+
+  for l:line in a:raw_yanks
+    if l:line =~ '^\t'
+      call add(l:yank_parts, l:line[1:])
+    elseif len(yank_parts) != 0
+      let l:yank = join(yank_parts, "\n")
+      call add(l:yanks, l:yank)
+      let l:yank_parts = []
+    endif
+  endfor
+
+  return reverse(l:yanks)
+endfunction
+
+function! s:yank_handler(cmd) abort
+  let l:content = a:cmd[0]
+  let @" = l:content
+  execute 'put "'
+endfunction

--- a/autoload/coc_fzf/yanks.vim
+++ b/autoload/coc_fzf/yanks.vim
@@ -1,11 +1,12 @@
 " description: list of yanks provided by coc-yank
 
 let s:prompt = 'Coc Yanks> '
-let s:yank_file_path = $HOME . '/.config/coc/extensions/coc-yank-data/yank'
+let s:yank_relative_file_path = '/coc-yank-data/yank'
 
 function! coc_fzf#yanks#fzf_run() abort
   call coc_fzf#common#log_function_call(expand('<sfile>'), a:000)
-  let l:raw_yanks = readfile(s:yank_file_path)
+  let l:yank_file_path = coc#util#extension_root() . s:yank_relative_file_path
+  let l:raw_yanks = readfile(l:yank_file_path)
   let l:opts = {
         \ 'source': s:get_yanks(l:raw_yanks),
         \ 'sink*': function('s:yank_handler'),

--- a/autoload/coc_fzf/yanks.vim
+++ b/autoload/coc_fzf/yanks.vim
@@ -40,6 +40,12 @@ endfunction
 
 function! s:yank_handler(cmd) abort
   let l:content = a:cmd[0]
-  let @" = l:content
-  execute 'put "'
+  if &cb == "unnamedplus"
+    let @+ = l:content
+  elseif &cb == "unnamed"
+    let @* = l:content
+  else
+    let @" = l:content
+  endif
+  put
 endfunction

--- a/doc/coc-fzf.txt
+++ b/doc/coc-fzf.txt
@@ -58,6 +58,7 @@ Commands ~
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                             |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                            |
+| `:CocFzfList yanks`                       | Equivalent to :CocList yank. Requires coc-yank [9]                         |
 | `:CocFzfListResume`                       | Equivalent to :CocListResume                                               |
 
 ===============================================================================
@@ -111,5 +112,6 @@ References ~
 [6] https://github.com/junegunn/fzf/blob/master/README-VIM.md
 [7] https://github.com/junegunn/fzf.vim
 [8] https://github.com/universal-ctags/ctags
+[9] https://github.com/neoclide/coc-yank
 
 vim: ft=help

--- a/doc/coc-fzf.txt
+++ b/doc/coc-fzf.txt
@@ -58,7 +58,7 @@ Commands ~
 | `:CocFzfList symbols`                     | Equivalent to :CocList symbols                                             |
 | `:CocFzfList symbols --kind {kind}`       | Equivalent to :CocList symbols -kind {kind}                                |
 | `:CocFzfList services`                    | Equivalent to :CocList services                                            |
-| `:CocFzfList yanks`                       | Equivalent to :CocList yank. Requires coc-yank [9]                         |
+| `:CocFzfList yank`                        | Equivalent to :CocList yank. Requires coc-yank [9]                         |
 | `:CocFzfListResume`                       | Equivalent to :CocListResume                                               |
 
 ===============================================================================


### PR DESCRIPTION
As discussed on #14, I went ahead and gave the yanks list a try.

After delving a bit onto `coc-yank`s repo, I couldn't find any easy way to obtain the list info directly, so instead I decided to parse the file it uses internally to save the yank history. Eventually I think it would be possible to provide a `Coc` command to access any list (since there's a well defined `List` interface as far as I could see), but for the time being this was an easy and fast way to get it working.
As for the implementation itself, I based this list on how the other ones looked like (it's my first time working with vimscript), adapting it a bit to what this particular list should do.

Let me know what you think!