### PR TITLE
Pass file argument to list actions

### DIFF
--- a/autoload/coc_fzf/common.vim
+++ b/autoload/coc_fzf/common.vim
@@ -89,3 +89,28 @@ function coc_fzf#common#fzf_run_with_preview(opts, ...) abort
   call coc_fzf#common_fzf_vim#merge_opts(merged, eopts)
   call fzf#run(fzf#wrap(merged))
 endfunction
+
+let s:default_action = {
+  \ 'ctrl-t': 'tab split',
+  \ 'ctrl-x': 'split',
+  \ 'ctrl-v': 'vsplit'}
+
+function coc_fzf#common#get_default_file_expect_keys() abort
+  return join(keys(get(g:, 'fzf_action', s:default_action)), ',')
+endfunction
+
+function coc_fzf#common#process_file_action(key, selected_item) abort
+  let l:cmd = get(get(g:, 'fzf_action', s:default_action), a:key)
+
+  if !empty(cmd) && stridx('edit', cmd) < 0
+    execute 'silent' cmd a:selected_item["filename"]
+  else
+    execute 'buffer' bufnr(a:selected_item["filename"], 1)
+  endif
+
+  if type(a:selected_item) == v:t_dict
+    mark '
+    call cursor(a:selected_item["lnum"], a:selected_item["col"])
+    normal! zz
+  endif
+endfunction

--- a/autoload/coc_fzf/symbols.vim
+++ b/autoload/coc_fzf/symbols.vim
@@ -27,7 +27,7 @@ function! coc_fzf#symbols#fzf_run(...) abort
     endif
     let l:ws_symbols_opts += a:000[l:kind_idx : l:kind_idx+1]
   endif
-  let expect_keys = join(keys(get(g:, 'fzf_action', s:default_action)), ',')
+  let expect_keys = coc_fzf#common#get_default_file_expect_keys()
   let command_fmt = python3 . ' ' . g:coc_fzf_plugin_dir . '/script/get_workspace_symbols.py %s %s %s %s'
   let initial_command = printf(command_fmt, join(l:ws_symbols_opts), v:servername, bufnr(), "''")
   let reload_command = printf(command_fmt, join(l:ws_symbols_opts), v:servername, bufnr(), '{q}')
@@ -39,17 +39,6 @@ function! coc_fzf#symbols#fzf_run(...) abort
         \ }
   call coc_fzf#common#fzf_run_with_preview(l:opts, {'placeholder': '{3}'})
   call s:syntax()
-endfunction
-
-let s:default_action = {
-  \ 'ctrl-t': 'tab split',
-  \ 'ctrl-x': 'split',
-  \ 'ctrl-v': 'vsplit'}
-
-function! s:action_for(key, ...)
-  let default = a:0 ? a:1 : ''
-  let l:Cmd = get(get(g:, 'fzf_action', s:default_action), a:key, default)
-  return l:Cmd
 endfunction
 
 function! s:syntax() abort
@@ -71,19 +60,8 @@ function! s:syntax() abort
 endfunction
 
 function! s:symbol_handler(sym) abort
-  let cmd = s:action_for(a:sym[0])
-  if !empty(cmd) && stridx('edit', cmd) < 0
-    if stridx('edit', cmd) < 0
-      execute 'silent' cmd
-    endif
-  endif
   let l:parsed = s:parse_symbol(a:sym[1:])
-  if type(l:parsed) == v:t_dict
-    execute 'buffer' bufnr(l:parsed["filename"], 1)
-    mark '
-    call cursor(l:parsed["lnum"], l:parsed["col"])
-    normal! zz
-  endif
+  call coc_fzf#common#process_file_action(a:sym[0], l:parsed)
 endfunction
 
 function! s:parse_symbol(sym) abort


### PR DESCRIPTION
I noticed that when using the location list (applies to any list that handles files though), one of my fzf actions was not working correctly. Turns out I have my `ctrl-t` bound to `tab drop`, which either opens a file in a new tab or switches to the corresponding tab if the file is already open; this works okay with `fzf.vim` but it was failing on `coc-fzf`, always opening the file on the current buffer.
Doing some digging, figured out that `tab drop` expects a filepath argument which was not being passed in by `coc-fzf`.

I did a couple of changes here to attempt to make `coc-fzf` behave similarly to what `fzf.vim` does and provide the filepath argument to the command being executed, falling back to opening the file on the current buffer if no command provided. Also took the chance to do a bit of a refactor and created a couple of util functions with some common logic that I saw on some other lists.
@antoinemadec wanted to run this through you first to see what you think; if you like it, I can go ahead and make use of this new util functions on other places that have the same logic.
Let me know what you think!