### PR TITLE
Don't show warning if bash is not in PATH but previews are disabled.

### DIFF
--- a/after/plugin/coc_fzf.vim
+++ b/after/plugin/coc_fzf.vim
@@ -1,11 +1,16 @@
 " test other plugins availability
 
-let g:coc_fzf_preview_available = 1
-try
-  call fzf#vim#with_preview()
-catch
+if exists('g:fzf_preview_window') && !len(g:fzf_preview_window)
   let g:coc_fzf_preview_available = 0
-endtry
+else
+  let g:coc_fzf_preview_available = 1
+  try
+    call fzf#vim#with_preview()
+  catch
+    let g:coc_fzf_preview_available = 0
+  endtry
+endif
+
 
 if g:coc_fzf_preview_available
   augroup CocFzfLocation


### PR DESCRIPTION
Fixes #71 

Checks if `g:fzf_preview_window` is an empty string. If that is true, `fzf#vim#with_preview()` is not called.