### PR TITLE
Display actions specific to the current line in actions list

### DIFF
--- a/autoload/coc_fzf/actions.vim
+++ b/autoload/coc_fzf/actions.vim
@@ -2,13 +2,20 @@
 
 let s:prompt = 'Coc Actions> '
 
-function! coc_fzf#actions#fzf_run() abort
+" Pass zero to run for the global buffer and current line, non-zero to run
+" according to visualmode()
+function! coc_fzf#actions#fzf_run(range) abort
   call coc_fzf#common#log_function_call(expand('<sfile>'), a:000)
-  " Get the global actions as well as actions for the current line,
-  " deduplicate them as well, n^2 algo for uniq from
-  " https://stackoverflow.com/questions/6630860/remove-duplicates-from-a-list-in-vim
-  let actions_with_duplicates= CocAction('codeActions', 'n') + CocAction('codeActions')
-  let g:coc_fzf_actions = filter(copy(actions_with_duplicates), 'index(actions_with_duplicates, v:val, v:key+1)==-1')
+  if a:range != 0
+    " If the user has specified a range, respect that
+    let g:coc_fzf_actions = CocAction('codeActions', visualmode())
+  else
+    " Get the global actions as well as actions for the current line,
+    " deduplicate them as well, n^2 algo for uniq from
+    " https://stackoverflow.com/questions/6630860/remove-duplicates-from-a-list-in-vim
+    let actions_with_duplicates= CocAction('codeActions', 'n') + CocAction('codeActions')
+    let g:coc_fzf_actions = filter(copy(actions_with_duplicates), 'index(actions_with_duplicates, v:val, v:key+1)==-1')
+  endif
   if !empty(g:coc_fzf_actions)
     let expect_keys = coc_fzf#common#get_default_file_expect_keys()
     let opts = {

--- a/autoload/coc_fzf/actions.vim
+++ b/autoload/coc_fzf/actions.vim
@@ -4,7 +4,11 @@ let s:prompt = 'Coc Actions> '
 
 function! coc_fzf#actions#fzf_run() abort
   call coc_fzf#common#log_function_call(expand('<sfile>'), a:000)
-  let g:coc_fzf_actions = CocAction('codeActions')
+  " Get the global actions as well as actions for the current line,
+  " deduplicate them as well, n^2 algo for uniq from
+  " https://stackoverflow.com/questions/6630860/remove-duplicates-from-a-list-in-vim
+  let actions_with_duplicates= CocAction('codeActions', 'n') + CocAction('codeActions')
+  let g:coc_fzf_actions = filter(copy(actions_with_duplicates), 'index(actions_with_duplicates, v:val, v:key+1)==-1')
   if !empty(g:coc_fzf_actions)
     let expect_keys = coc_fzf#common#get_default_file_expect_keys()
     let opts = {

--- a/autoload/coc_fzf/lists.vim
+++ b/autoload/coc_fzf/lists.vim
@@ -2,12 +2,13 @@
 
 let s:prompt = 'Coc Lists> '
 
-function! coc_fzf#lists#fzf_run(...) abort
+function! coc_fzf#lists#fzf_run(range, ...) abort
   let s:list_sources = coc_fzf#common#get_list_sources()
   if a:0 && a:1[0] != '-'
     " execute one source/list
     let src = a:000[0]
-    let src_opts = a:000[1:]
+    " Append range to arguments
+    let src_opts = a:000[1:] + [a:range]
     call s:run_source(src, src_opts)
   else
     " prompt all available lists

--- a/plugin/coc_fzf.vim
+++ b/plugin/coc_fzf.vim
@@ -21,5 +21,5 @@ endif
 let g:coc_fzf_plugin_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 let g:coc_fzf_plugin_dir = fnamemodify(g:coc_fzf_plugin_dir, ':h')
 
-command! -nargs=* -complete=custom,coc_fzf#common#list_options CocFzfList call coc_fzf#lists#fzf_run(<f-args>)
+command! -range -nargs=* -complete=custom,coc_fzf#common#list_options CocFzfList call coc_fzf#lists#fzf_run(<range>, <f-args>)
 command CocFzfListResume call coc_fzf#common#call_last_logged_function()


### PR DESCRIPTION
It may be desirable to use a deduplicating algorithm with a better complexity

I haven't thought about this very much or used it in anger, but thought it was worth opening a PR anyway, feel free to make whatever changes would be good, like using `codeActionsRange`, and ideally making just one call to coc and dropping the deduplicating part (although I don't know if this is possible).