### PR TITLE
fix no syntax when open files in CocLocationsChange using tmux floating window.

### DIFF
--- a/after/plugin/coc_fzf.vim
+++ b/after/plugin/coc_fzf.vim
@@ -15,10 +15,10 @@ augroup CocFzfLocation
   autocmd!
   let g:coc_enable_locationlist = 0
   if has('nvim')
-    autocmd User CocLocationsChange call coc_fzf#location#fzf_run()
+    autocmd User CocLocationsChange nested call coc_fzf#location#fzf_run()
   else
     " avoid weird race condition in Vim
-    autocmd User CocLocationsChange call timer_start(10, 'CocFzfLocationsVimRun')
+    autocmd User CocLocationsChange nested call timer_start(10, 'CocFzfLocationsVimRun')
     function! CocFzfLocationsVimRun(id)
       call coc_fzf#location#fzf_run()
     endfunction


### PR DESCRIPTION
### Description
When some files opened in CocLocationsChange using tmux floating window, no syntax highlight like plain text.
According to [this issue](https://github.com/neoclide/coc.nvim/issues/2672),  you have to use  ```nested``` option in autocmd.

### Screen capture
#### before
![before](https://user-images.githubusercontent.com/6185139/106386573-fbb70380-6418-11eb-8f1f-9ad283672d8d.gif)

#### after
![after](https://user-images.githubusercontent.com/6185139/106386579-fe195d80-6418-11eb-894a-8cda12396be2.gif)
