### PR TITLE
Add option to open fullscreen search with preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ call coc_fzf#common#delete_list_source('fzf-buffers')
 | Option                         | Type   | Description                                                    | Default value               |
 | ---                            | ---    | ---                                                            | ---                         |
 | `g:coc_fzf_preview_toggle_key` | string | Change the key to toggle the preview window                    | `'?'`                       |
+| `g:coc_fzf_preview_fullscreen` | number | Set to 1 to use FZF fullscreen mode in coc-references etc.     | `0`                         |
 | `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
 | `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. `['--layout=reverse']` | `['--layout=reverse-list']` |
 

--- a/autoload/coc_fzf/common.vim
+++ b/autoload/coc_fzf/common.vim
@@ -198,7 +198,7 @@ function coc_fzf#common#fzf_run_with_preview(opts, ...) abort
   let eopts  = has_key(extra, 'options') ? remove(extra, 'options') : ''
   let merged = extend(copy(a:opts), extra)
   call coc_fzf#common_fzf_vim#merge_opts(merged, eopts)
-  call fzf#run(fzf#wrap(merged))
+  call fzf#run(fzf#wrap(merged, g:coc_fzf_preview_fullscreen))
 endfunction
 
 let s:default_action = {

--- a/doc/coc-fzf.txt
+++ b/doc/coc-fzf.txt
@@ -124,6 +124,7 @@ Options ~
 
 | Option                       | Type   | Description                                                    | Default value             | ~
 | `g:coc_fzf_preview_toggle_key` | string | Change the key to toggle the preview window                    | `'?'`                       |
+| `g:coc_fzf_preview_fullscreen` | string | Set to 1 to use FZF fullscreen mode in coc-references etc.     | `0`                         |
 | `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
 | `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. "['--layout=reverse']" | `['--layout=reverse-list']` |
 

--- a/plugin/coc_fzf.vim
+++ b/plugin/coc_fzf.vim
@@ -14,6 +14,9 @@ endif
 if !exists("g:coc_fzf_preview")
     let g:coc_fzf_preview = 'up:50%'
 endif
+if !exists("g:coc_fzf_preview_fullscreen")
+    let g:coc_fzf_preview_fullscreen = 0
+endif
 if !exists("g:coc_fzf_opts")
     let g:coc_fzf_opts = ['--layout=reverse-list']
 endif


### PR DESCRIPTION
Refer to issue #98 

Changes:
- Added new option `g:coc_fzf_preview_fullscreen`
- When set to 1, FZF default fullscreen mode will be enabled in commands like `coc-references` and related commands
- Defaults to 0, retaining current behavior