### PR TITLE
fix(actions): Extract client ID from command

### DIFF
--- a/autoload/coc_fzf/actions.vim
+++ b/autoload/coc_fzf/actions.vim
@@ -35,8 +35,11 @@ endfunction
 
 function! s:format_coc_action(item) abort
   " title [clientId] (kind)
+  let command = get(get(a:item, 'command', {}), 'command', '')
+  let index = stridx(l:command, '.')
+  let client_id = l:index < 1 ? '' : l:command[:index - 1]
   let str = a:item.title .
-        \ coc_fzf#common_fzf_vim#yellow(' [' . a:item.clientId . ']', 'Type')
+        \ (empty(l:client_id) ? '' : coc_fzf#common_fzf_vim#yellow(' [' . l:client_id . ']', 'Type'))
   if exists('a:item.kind')
     let str .=  coc_fzf#common_fzf_vim#green(' (' . a:item.kind . ')', 'Comment')
   endif


### PR DESCRIPTION
The `clientId` attribute was removed in [1]. Now there are a few
different places where we can obtain this info but after checking
rust-analyzer, jdt.ls and cSpell, `a:item.command.command` is the only
one that's always available.

[1] https://github.com/neoclide/coc.nvim/commit/9fbbb30098e5a436c64a23b94610cabec3cffa5a
