### PR TITLE
Fix external cmds may stuck.

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ call coc_fzf#common#delete_list_source('fzf-buffers')
 | `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
 | `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. `['--layout=reverse']` | `['--layout=reverse-list']` |
 | `g:coc_fzf_location_delay`     | number | Delay(ms) fzf_run() to solve weird race conditions.            | 0                           |
+| `g:coc_fzf_command_delay`      | number | Delay(ms) source cmds to solve weird race conditions.          | 0                           |
 
 ## Vimrc Example
 ```vim

--- a/autoload/coc_fzf/lists.vim
+++ b/autoload/coc_fzf/lists.vim
@@ -38,7 +38,11 @@ function s:run_source(src, range, ...) abort
     let str_opts = empty(src_opts) ? '' : ' ' . join(src_opts)
     let cmd = wrapper . str_opts
     call coc_fzf#common#log_function_call('execute', [cmd])
-    call timer_start(g:coc_fzf_location_delay, { -> execute(cmd)})
+    if g:coc_fzf_command_delay > 0
+      call timer_start(g:coc_fzf_command_delay, { -> execute(cmd)})
+    else
+      execute cmd
+    endif
   endif
 endfunction
 

--- a/autoload/coc_fzf/lists.vim
+++ b/autoload/coc_fzf/lists.vim
@@ -38,7 +38,7 @@ function s:run_source(src, range, ...) abort
     let str_opts = empty(src_opts) ? '' : ' ' . join(src_opts)
     let cmd = wrapper . str_opts
     call coc_fzf#common#log_function_call('execute', [cmd])
-    execute cmd
+    call timer_start(g:coc_fzf_location_delay, { -> execute(cmd)})
   endif
 endfunction
 

--- a/doc/coc-fzf.txt
+++ b/doc/coc-fzf.txt
@@ -128,6 +128,7 @@ Options ~
 | `g:coc_fzf_preview`            | string | Change the preview window position                             | `'up:50%'`                  |
 | `g:coc_fzf_opts`               | array  | Pass additional parameters to fzf, e.g. "['--layout=reverse']" | `['--layout=reverse-list']` |
 | `g:coc_fzf_location_delay`     | number | Delay(ms) fzf_run() to solve weird race conditions.            | 0                         |
+| `g:coc_fzf_command_delay`      | number | Delay(ms) source cmds to solve weird race conditions.          | 0                         |
 
 ===============================================================================
                                                         *coc-fzf-vimrc-example*

--- a/plugin/coc_fzf.vim
+++ b/plugin/coc_fzf.vim
@@ -23,6 +23,9 @@ endif
 if !exists("g:coc_fzf_location_delay")
   let g:coc_fzf_location_delay = 0
 endif
+if !exists("g:coc_fzf_command_delay")
+  let g:coc_fzf_command_delay = 0
+endif
 
 let g:coc_fzf_plugin_dir = fnamemodify(resolve(expand('<sfile>:p')), ':h')
 let g:coc_fzf_plugin_dir = fnamemodify(g:coc_fzf_plugin_dir, ':h')


### PR DESCRIPTION
For example, with the following config
```
call coc_fzf#common#add_list_source('helptags', 'helptags of vim', 'Leaderf help')
```
If I type `:CocFzfList<CR>` then `helptags<CR>`, the whole vim will stuck forever.
I tried `vim -V9myVim.log`, from the log, it's keep doing `chdir()`.
So I guess it's a weird race conditions between `fzf` and `LeaderF`, may not related to `coc-fzf`.
Here is a simple workaround.